### PR TITLE
Remove test files from published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,4 @@
+.gitmodules
+.travis.yml
+test.js
 vendor/


### PR DESCRIPTION
These test files are unnecessary for the published package and increase the file size slightly.

This removes `test.js`, `.travis.yml`, and `.gitmodules` (see `npm pack --dry-run` for the full list).